### PR TITLE
refactor: as per chat gpt recommendations

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,7 +1,8 @@
 import java.net.ServerSocket;
 
-fun main() {
+fun main(args: Array<String>) {
     // You can use print statements as follows for debugging, they'll be visible when running tests.
     println("Logs from your program will appear here!")
-    MyHttpServer(ServerSocket(SERVER_PORT)).initServer()
+    val port = if (args.size != 2) SERVER_PORT else args[1].toInt()
+    MyHttpServer(ServerSocket(port)).initServer()
 }

--- a/src/main/kotlin/MyHttpServer.kt
+++ b/src/main/kotlin/MyHttpServer.kt
@@ -5,96 +5,111 @@ import java.net.Socket
 const val SERVER_PORT = 4221
 
 class MyHttpServer(private val serverSocket: ServerSocket) {
-    private var clientBufferedReader: BufferedReader? = null
 
     fun initServer(endlessLoop: Boolean = true) {
-        // // Since the tester restarts your program quite often, setting SO_REUSEADDR
-        // // ensures that we don't run into 'Address already in use' errors
         serverSocket.reuseAddress = true
         var ranOnce = false
 
         while (!ranOnce || endlessLoop) {
-            val clientSocket = serverSocket.accept() // Wait for connection from client.
-            println("accepted new connection")
-            val urlPath = extractUrlPath(clientSocket)
-            println("urlPath: $urlPath")
-            val responseStatus = handleUrlPath(urlPath)
-            println("response status: $responseStatus")
-            val out = clientSocket.getOutputStream()
-            out.write(buildResponse(responseStatus, urlPath, clientSocket))
-            out.flush()
-            clientSocket.close()
-            ranOnce = true
-            if (urlPath == KnownUrlPaths.STOP.urlPath) {
-                closeServer()
-                return
+            serverSocket.accept().use { clientSocket ->
+                println("Accepted new connection")
+
+                val bufferedReader = clientSocket.getInputStream().bufferedReader()
+                val requestLine = bufferedReader.readLine().orEmpty()
+                val urlPath = extractUrlPath(requestLine)
+
+                println("urlPath: $urlPath")
+
+                val responseStatus = determineStatus(urlPath)
+                println("response status: $responseStatus")
+
+                val responseBytes = buildResponse(responseStatus, urlPath, bufferedReader)
+                clientSocket.getOutputStream().use { out ->
+                    out.write(responseBytes)
+                    out.flush()
+                }
+
+                if (urlPath == KnownUrlPaths.STOP.urlPath) {
+                    closeServer()
+                    return
+                }
+                ranOnce = true
             }
         }
     }
 
-    fun closeServer() {
-        serverSocket.close()
-    }
-
-    private fun buildResponse(httpStatus: HttpStatus, urlPath: String, clientSocket: Socket): ByteArray {
-        val responseBody = buildResponseBody(urlPath)
+    private fun buildResponse(httpStatus: HttpStatus, urlPath: String, reader: BufferedReader): ByteArray {
+        val responseBody = buildResponseBody(urlPath, reader)
         val response = "HTTP/1.1 $httpStatus\r\n$responseBody"
-        println("final response:$response")
-        println("end of final response")
+        println("Final response: $response")
+        println("End of final response")
         return response.toByteArray()
     }
 
-    private fun buildResponseBody(urlPath: String): String {
-        val body = when (val firstResource = getFirstResource(urlPath)) {
-            KnownUrlPaths.ECHO.urlPath -> urlPath.replace(firstResource, " ").trim().substring(1)
-
-            KnownUrlPaths.USER_AGENT.urlPath -> getUserAgentValue()
+    private fun buildResponseBody(urlPath: String, reader: BufferedReader): String {
+        val body = when (val resource = getFirstResource(urlPath)) {
+            KnownUrlPaths.ECHO.urlPath -> urlPath.removePrefix(resource).trimStart('/')
+            KnownUrlPaths.USER_AGENT.urlPath -> extractUserAgent(reader)
             else -> ""
         }
-        return if (body.isEmpty()) "\r\n" else "Content-Type: text/plain\r\nContent-Length: ${body.length}\r\n\r\n$body"
+        return if (body.isEmpty()) "\r\n" else
+            "Content-Type: text/plain\r\nContent-Length: ${body.length}\r\n\r\n$body"
     }
 
-    private fun getUserAgentValue(): String {
-        val userAgentHeader = "User-Agent:"
-        while (true) {
-            val line = clientBufferedReader?.readLine() ?: return ""
-            if (line.startsWith(userAgentHeader)) return line.replace(userAgentHeader, " ").trim()
-        }
+    private fun extractUserAgent(reader: BufferedReader): String {
+        val userAgentPrefix = "User-Agent:"
+        return generateSequence { reader.readLine() }
+            .firstOrNull { it.startsWith(userAgentPrefix) }
+            ?.removePrefix(userAgentPrefix)
+            ?.trim()
+            .orEmpty()
     }
 
-    private fun extractUrlPath(clientSocket: Socket): String {
-        clientBufferedReader = clientSocket.getInputStream().bufferedReader()
-        val request1stLine = clientBufferedReader?.readLine() ?: return ""
-        val firstSlashIndex = request1stLine.indexOf("/")
-        val httpIndex = request1stLine.indexOf("HTTP")
-        return request1stLine.substring(firstSlashIndex, httpIndex).trim()
+    private fun extractUrlPath(requestLine: String): String {
+        val firstSlash = requestLine.indexOf('/')
+        val httpIndex = requestLine.indexOf("HTTP")
+        return if (firstSlash != -1 && httpIndex != -1) {
+            requestLine.substring(firstSlash, httpIndex).trim()
+        } else ""
     }
 
-    private fun handleUrlPath(urlPath: String): HttpStatus {
-        val firstResource = getFirstResource(urlPath)
+    private fun determineStatus(urlPath: String): HttpStatus {
+        val resource = getFirstResource(urlPath)
         return when {
             urlPath.isEmpty() -> HttpStatus.BAD_REQUEST
-            KnownUrlPaths.isUrlPathKnown(firstResource) -> HttpStatus.OK
+            KnownUrlPaths.isUrlPathKnown(resource) -> HttpStatus.OK
             else -> HttpStatus.NOT_FOUND
         }
     }
 
     private fun getFirstResource(urlPath: String): String {
-        val secondResourceIndex = urlPath.replaceFirst('/', ' ').indexOf('/')
-        return if (secondResourceIndex == -1) urlPath else urlPath.substring(0, secondResourceIndex)
+        val withoutFirstSlash = urlPath.removePrefix("/")
+        val nextSlashIndex = withoutFirstSlash.indexOf('/')
+        return if (nextSlashIndex == -1) "/$withoutFirstSlash" else "/${withoutFirstSlash.substring(0, nextSlashIndex)}"
+    }
+
+    fun closeServer() {
+        serverSocket.close()
     }
 }
 
-enum class HttpStatus(private val code: Int, private val status: String) {
-    OK(200, "OK"), BAD_REQUEST(400, "Bad Request"), NOT_FOUND(404, "Not Found");
+enum class HttpStatus(private val code: Int, private val statusText: String) {
+    OK(200, "OK"),
+    BAD_REQUEST(400, "Bad Request"),
+    NOT_FOUND(404, "Not Found");
 
-    override fun toString(): String = "$code $status"
+    override fun toString(): String = "$code $statusText"
 }
 
 enum class KnownUrlPaths(val urlPath: String) {
-    ROOT("/"), ROOT_2(""), ECHO("/echo"), USER_AGENT("/user-agent"), STOP("/stop");
+    ROOT("/"),
+    ROOT_2(""),
+    ECHO("/echo"),
+    USER_AGENT("/user-agent"),
+    STOP("/stop");
 
     companion object {
-        fun isUrlPathKnown(urlPath: String): Boolean = entries.any { it.urlPath == urlPath }
+        fun isUrlPathKnown(path: String): Boolean =
+            entries.any { it.urlPath == path }
     }
 }

--- a/src/test/java/MainKtTest.kt
+++ b/src/test/java/MainKtTest.kt
@@ -1,25 +1,21 @@
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import khttp.get
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import java.lang.Thread.sleep
 import kotlin.concurrent.thread
+
+private const val SERVER_PORT_TEST = 4222
 
 class MainKtTest {
     @Test
     fun `given and endless loop running http server, when making multiple valid requests, then the server responds well`() {
-        val okSimpleResponse = "HTTP/1.1 200 OK\r\n\r\n".toByteArray()
-        val notFoundResponse = "HTTP/1.1 404 Not Found\r\n\r\n".toByteArray()
         val userAgentValue = "Agent 47"
-        val userAgentResponse =
-            "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: ${userAgentValue.length}\r\n\r\n$userAgentValue".toByteArray()
 
         runBlocking {
             thread {
-                main()
+                main(arrayOf("httpServer", SERVER_PORT_TEST.toString()))
             }
 
             delay(500)
@@ -46,11 +42,11 @@ class MainKtTest {
             }.joinAll()
         }
 
-        get("http://localhost:$SERVER_PORT/stop")
+        get("http://localhost:$SERVER_PORT_TEST/stop")
     }
 
     private fun userAgentHttpCall(userAgentValue: String) {
-        val result = get("http://localhost:$SERVER_PORT/user-agent", mapOf("User-Agent" to userAgentValue))
+        val result = get("http://localhost:$SERVER_PORT_TEST/user-agent", mapOf("User-Agent" to userAgentValue))
         val statusCode = result.statusCode
         val body = String(result.content)
         assert(statusCode == 200) { "status code was $statusCode" }
@@ -58,13 +54,13 @@ class MainKtTest {
     }
 
     private fun notFoundHttpCall() {
-        val result = get("http://localhost:$SERVER_PORT/abcde")
+        val result = get("http://localhost:$SERVER_PORT_TEST/abcde")
         val statusCode = result.statusCode
         assert(statusCode == 404) { "status code was $statusCode" }
     }
 
     private fun simpleRootHttpCall() {
-        val result = get("http://localhost:$SERVER_PORT")
+        val result = get("http://localhost:$SERVER_PORT_TEST")
         val statusCode = result.statusCode
         val body = String(result.content)
         assert(statusCode == 200) { "status code was $statusCode" }


### PR DESCRIPTION
Key Improvements:
Use use blocks (socket.use {} and stream.use {}) to properly auto-close resources even on exceptions.

Avoid nullable fields: clientBufferedReader was moved inside initServer, no longer stored globally.

Kotlin-idiomatic file reading: Using generateSequence for reading headers.

String handling: Using removePrefix, trimStart, etc., very clean for URL paths.

Slightly improved names: handleUrlPath -> determineStatus (because it determines status).

Smaller and more focused functions: now every method has one responsibility.